### PR TITLE
fix(#148 - Inspection Images) - Allow audio, images, and video in accepts attribute

### DIFF
--- a/DigitalInspection/Views/Inspections/_UploadInspectionPhotosDialog.cshtml
+++ b/DigitalInspection/Views/Inspections/_UploadInspectionPhotosDialog.cshtml
@@ -57,7 +57,7 @@
 							<label for="fileInput" class="btn btn-primary">
 								<i class="material-icons md-36">camera_alt</i>
 							</label>
-							@Html.TextBoxFor(m => m.Picture, new { type = "file", accept = "image/*,video/*", id = "fileInput", capture = "environment" })
+							@Html.TextBoxFor(m => m.Picture, new { type = "file", accept = "image/*,video/*,audio/*", id = "fileInput", capture = "environment" })
 						</div>
 					</div>
 


### PR DESCRIPTION
Per Steve's local testing with reporters reproducing this issue in their browsers, adding the extraneous accepts field mitigated their issues. Producing a build via pull request to allow A/B testing vs the prior fix for capture attribute alone.